### PR TITLE
Fix get userProfile issue

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -117,29 +117,12 @@ util.inherits(Strategy, OAuth2Strategy);
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
   var self = this;
-  this._oauth2._useAuthorizationHeaderForGET = true;
-  this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
     var json;
 
-    if (err) {
-      if (err.data) {
-        try {
-          json = JSON.parse(err.data);
-        } catch (_) {}
-      }
-
-      if (json && json.error && json.error.message) {
-        return done(new UserInfoError(json.error.message, json.error.code));
-      } else if (json && json.error && json.error_description) {
-        return done(new UserInfoError(json.error_description, json.error));
-      }
-      return done(new InternalOAuthError('Failed to fetch user profile', err));
-    }
-
     try {
-      json = JSON.parse(body);
+        json = JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64').toString());
     } catch (ex) {
-      return done(new Error('Failed to parse user profile'));
+        return done(new Error('Failed to parse access token'));
     }
 
     var profile = { realm: self.options.realm, provider: 'keycloak' };
@@ -148,9 +131,9 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     profile.email = json.email || '';
     profile.name = json.name || '';
     profile.given_name = json.given_name || '';
-    profile.given_name = json.family_name || '';
+    profile.family_name = json.family_name || '';
     profile.email_verified = json.email_verified || '';
-    profile.roles = json.roles || '';
+    profile.roles = json.realm_access.roles || '';
 
     // profile._raw = body;
     profile._json = json;


### PR DESCRIPTION
The userProfile request fails, as scope 'openid' is missing. Anyway profile does not contain roles by default but the access token does contain all needed data.