### PR TITLE
Correct given/family name mappings

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -148,7 +148,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     profile.email = json.email || '';
     profile.name = json.name || '';
     profile.given_name = json.given_name || '';
-    profile.given_name = json.family_name || '';
+    profile.family_name = json.family_name || '';
     profile.email_verified = json.email_verified || '';
     profile.roles = json.roles || '';
 


### PR DESCRIPTION
This corrects the incorrect `given_name` mapping and absent `family_name` mapping done by the strategy

Closes: #7